### PR TITLE
Fix two bugs gcc warnings pointed out

### DIFF
--- a/conjunction.c
+++ b/conjunction.c
@@ -8,7 +8,7 @@ DYAD(amper) { V *v; A z; I xt = AT(x), yt = AT(y);
         v = VAV(xt&VERB ? x : y);
         z = CDERV(CAMPR, bond, bond2, x, y, VLR(v), VMR(v), VRR(v));
     }
-    else if (xt&VERB && yt&&VERB) {
+    else if (xt&VERB && yt&VERB) {
         v = VAV(y);
         z = CDERV(CAMPR, compose, compose2, x, y, VLR(v), VMR(v), VRR(v));
     }

--- a/function.h
+++ b/function.h
@@ -1,5 +1,5 @@
 #ifndef _FUNCTION_H
-#define _FUNCITON_H
+#define _FUNCTION_H
 
 typedef struct _verb {
     AF1 f1;


### PR DESCRIPTION
My version of GCC produced a pile of warnings caused by what appear to be two small bugs.